### PR TITLE
Throw on uneven number of items and duplicate keys

### DIFF
--- a/src/edamame/impl/parser.cljc
+++ b/src/edamame/impl/parser.cljc
@@ -159,7 +159,7 @@
         ks (take-nth 2 elements)]
     (when (odd? (count elements))
       (throw-odd-map reader start-loc elements))
-    (when-not (= (count (set ks)) (count ks))
+    (when-not (apply distinct? ks)
       (throw-dup-keys reader start-loc :map ks))
     (apply hash-map elements)))
 

--- a/src/edamame/impl/parser.cljc
+++ b/src/edamame/impl/parser.cljc
@@ -38,12 +38,16 @@
   (apply list (parse-to-delimiter ctx reader \))))
 
 (defn throw-reader
-  "Throw reader exception, including line line/column."
+  "Throw reader exception, including line line/column. line/column is
+  read from the reader but it can be overriden by passing loc
+  optional parameter."
   ([#?(:cljs ^:not-native reader :default reader) msg]
    (throw-reader reader msg nil))
   ([#?(:cljs ^:not-native reader :default reader) msg data]
-   (let [c (r/get-column-number reader)
-         l (r/get-line-number reader)]
+   (throw-reader reader msg data nil))
+  ([#?(:cljs ^:not-native reader :default reader) msg data loc]
+   (let [c (:col loc (r/get-column-number reader))
+         l (:row loc (r/get-line-number reader))]
      (throw
       (ex-info
        (str msg
@@ -84,6 +88,10 @@
     (\{ \( \[ \") true
     false))
 
+(defn location [#?(:cljs ^not-native reader :default reader)]
+  {:row (r/get-line-number reader)
+   :col (r/get-column-number reader)})
+
 (defn- duplicate-keys-error [msg coll]
   ;; https://github.com/clojure/tools.reader/blob/97d5dac9f5e7c04d8fe6c4a52cd77d6ced560d76/src/main/cljs/cljs/tools/reader/impl/errors.cljs#L233
   (letfn [(duplicates [seq]
@@ -96,19 +104,22 @@
              ": " (interpose ", " dups)))))
 
 (defn throw-dup-keys
-  [#?(:cljs ^not-native reader :default reader) kind ks]
+  [#?(:cljs ^not-native reader :default reader) loc kind ks]
   (throw-reader
    reader
    (duplicate-keys-error
     (str (s/capitalize (name kind)) " literal contains duplicate key")
-    ks)))
+    ks)
+   nil
+   loc))
 
 (defn parse-set
   [ctx #?(:cljs ^not-native reader :default reader)]
-  (let [coll (parse-to-delimiter ctx reader \})
+  (let [start-loc (location reader)
+        coll (parse-to-delimiter ctx reader \})
         the-set (set coll)]
     (when-not (= (count coll) (count the-set))
-      (throw-dup-keys reader :set coll))
+      (throw-dup-keys reader start-loc :set coll))
     the-set))
 
 (defn parse-sharp
@@ -129,7 +140,7 @@
           (edn/read ctx reader))))))
 
 (defn throw-odd-map
-  [#?(:cljs ^not-native reader :default reader) elements]
+  [#?(:cljs ^not-native reader :default reader) loc elements]
   (throw-reader
    reader
    (str
@@ -137,16 +148,19 @@
     (i/inspect (first elements))
     " contains "
     (count elements)
-    " form(s). Map literals must contain an even number of forms.")))
+    " form(s). Map literals must contain an even number of forms.")
+   nil
+   loc))
 
 (defn parse-map
   [ctx #?(:cljs ^not-native reader :default reader)]
-  (let [elements (parse-to-delimiter ctx reader \})
+  (let [start-loc (location reader)
+        elements (parse-to-delimiter ctx reader \})
         ks (take-nth 2 elements)]
     (when (odd? (count elements))
-      (throw-odd-map reader elements))
+      (throw-odd-map reader start-loc elements))
     (when-not (= (count (set ks)) (count ks))
-      (throw-dup-keys reader :map ks))
+      (throw-dup-keys reader start-loc :map ks))
     (apply hash-map elements)))
 
 (defn dispatch
@@ -172,10 +186,6 @@
         \; (parse-comment reader)
         \# (parse-sharp ctx reader)
         (edn/read ctx reader)))))
-
-(defn location [#?(:cljs ^not-native reader :default reader)]
-  {:row (r/get-line-number reader)
-   :col (r/get-column-number reader)})
 
 (defn whitespace?
   [#?(:clj ^java.lang.Character c :default c)]

--- a/test/edamame/core_test.cljc
+++ b/test/edamame/core_test.cljc
@@ -12,7 +12,16 @@
   (is (= '(1 2 3) (p/parse-string "(1 2 3)")))
   (is ((every-pred vector? #(= % [1 2 3])) (p/parse-string "[1 2 3]")))
   (is (= #{1 2 3} (p/parse-string "#{1 2 3}")))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+                        #"Set literal contains duplicate key: 1"
+                        (p/parse-string "#{1 1}")))
   (is (= {:a 1 :b 2} (p/parse-string "{:a 1 :b 2}")))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+                        #"The map literal starting with :a contains 3 form\(s\)."
+                        (p/parse-string "{:a :b :c}")))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+                        #"Map literal contains duplicate key: :a"
+                        (p/parse-string "{:a :b :a :c}")))
   (is (= {:row 1 :col 2}  (meta (first (p/parse-string "[{:a 1 :b 2}]")))))
   (is (= {:foo true :row 1 :col 1} (meta (p/parse-string "^:foo {:a 1 :b 2}"))))
   (let [p (p/parse-string ";; foo\n{:a 1}")]

--- a/test/edamame/core_test.cljc
+++ b/test/edamame/core_test.cljc
@@ -13,14 +13,14 @@
   (is ((every-pred vector? #(= % [1 2 3])) (p/parse-string "[1 2 3]")))
   (is (= #{1 2 3} (p/parse-string "#{1 2 3}")))
   (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
-                        #"Set literal contains duplicate key: 1"
+                        #"Set literal contains duplicate key: 1 \[at line 1, column 2\]"
                         (p/parse-string "#{1 1}")))
   (is (= {:a 1 :b 2} (p/parse-string "{:a 1 :b 2}")))
   (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
-                        #"The map literal starting with :a contains 3 form\(s\)."
+                        #"The map literal starting with :a contains 3 form\(s\). Map literals must contain an even number of forms. \[at line 1, column 1\]"
                         (p/parse-string "{:a :b :c}")))
   (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
-                        #"Map literal contains duplicate key: :a"
+                        #"Map literal contains duplicate key: :a \[at line 1, column 1\]"
                         (p/parse-string "{:a :b :a :c}")))
   (is (= {:row 1 :col 2}  (meta (first (p/parse-string "[{:a 1 :b 2}]")))))
   (is (= {:foo true :row 1 :col 1} (meta (p/parse-string "^:foo {:a 1 :b 2}"))))


### PR DESCRIPTION
See discussion in Issue #7 

This PR changes map and set parsing so that:

- Error is thrown when map contains uneven number of elements
- Error is thrown when map contains duplicate keys
- Error is thrown when set contains duplicate keys

In addition, `throw-reader` is extended so that location can be passed as a parameter to override the reader location. This is useful when reporting map/set errors where the start location makes more sense than the end location.

The code is imitating tools.reader namespaces [tools.reader.edn](https://github.com/clojure/tools.reader/blob/97d5dac9f5e7c04d8fe6c4a52cd77d6ced560d76/src/main/cljs/cljs/tools/reader/edn.cljs) and [tools.reader.impl.errors](https://github.com/clojure/tools.reader/blob/97d5dac9f5e7c04d8fe6c4a52cd77d6ced560d76/src/main/cljs/cljs/tools/reader/impl/errors.cljs)