### PR TITLE
Use *default-data-reader-fn* if set

### DIFF
--- a/src/edamame/impl/parser.cljc
+++ b/src/edamame/impl/parser.cljc
@@ -14,6 +14,7 @@
    #?(:clj [clojure.tools.reader.impl.commons :as commons]
       :cljs [cljs.tools.reader.impl.commons :as commons])
    #?(:cljs [cljs.tagged-literals :as cljs-tags])
+   #?(:cljs [cljs.reader])
    [clojure.string :as str]
    [edamame.impl.read-fn :refer [read-fn]]
    [edamame.impl.syntax-quote :refer [syntax-quote]])
@@ -330,7 +331,9 @@
                   data (parse-next ctx reader)
                   f (or (get (:readers ctx) sym)
                         #?(:clj (default-data-readers sym)
-                           :cljs (cljs-tags/*cljs-data-readers* sym)))]
+                           :cljs (cljs-tags/*cljs-data-readers* sym))
+                        #?(:clj *default-data-reader-fn*
+                           :cljs cljs.reader/*default-data-reader-fn*))]
               (if f (f data)
                   (throw (new #?(:clj Exception :cljs js/Error)
                               (str "No reader function for tag " sym)))))

--- a/test/edamame/core_test.cljc
+++ b/test/edamame/core_test.cljc
@@ -5,6 +5,7 @@
    [edamame.core :as p]
    #?(:clj [clojure.java.io :as io])
    #?(:cljs [goog.object :as gobj])
+   #?(:cljs [cljs.reader])
    #?(:clj [cljs.tagged-literals :as cljs-tags])
    [edamame.test-utils]))
 
@@ -247,6 +248,13 @@
   (is (= '(js [1 2 3])  (p/parse-string "#js [1 2 3]" {:readers {'js (fn [v] (list 'js v))}})))
   ;; TODO: should we "eval" the JSValue here, or in sci?
   #?(:cljs (is (p/parse-string "#js [1 2 3]"))))
+
+(deftest default-data-reader-test
+  (set! #?(:clj *default-data-reader-fn*
+           :cljs cljs.reader/*default-data-reader-fn*) identity)
+  (is (= [1 2 3] (p/parse-string "#foo [1 2 3]")))
+  (set! #?(:clj *default-data-reader-fn*
+           :cljs cljs.reader/*default-data-reader-fn*) nil))
 
 (deftest namespaced-map-test
   ;; TODO: fix locations of namespaced maps


### PR DESCRIPTION
From https://clojure.org/reference/reader

> If no data reader is found for a tag, the function bound in `*default-data-reader-fn*` will be invoked with the tag and value to produce a value.

Should edamame also use `*default-data-reader-fn*`?