### PR TITLE
Add edamame/expected-delimiter to result data.

### DIFF
--- a/src/edamame/impl/parser.cljc
+++ b/src/edamame/impl/parser.cljc
@@ -120,7 +120,9 @@
            (kw-identical? ::eof next-val)
            (throw-reader ctx
             reader
-            (str "EOF while reading, expected " delimiter " to match " opened " at [" row "," col "]"))
+            (str "EOF while reading, expected " delimiter " to match " opened " at [" row "," col "]")
+            {:edamame/expected-delimiter delimiter
+             :edamame/opened-delimiter opened})
            (kw-identical? ::expected-delimiter next-val)
            (persistent! vals)
            cond-splice? (do (doseq [v next-val]

--- a/test/edamame/core_test.cljc
+++ b/test/edamame/core_test.cljc
@@ -106,10 +106,12 @@
     (is (= [] (p/parse-string-all (string/join "\n" (repeat 10000 ";;")))))))
 
 (deftest eof-while-reading-test
-  (doseq [s ["(" "{" "["]]
-    (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
-                          #"EOF while reading"
-                          (p/parse-string s))))
+  (doseq [s {"(" ")" "{" "}" "[" "]"}]
+    (is (thrown-with-data? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+                           #"EOF while reading"
+                           {:edamame/expected-delimiter (second s)
+                            :edamame/opened-delimiter (first s)}
+                           (p/parse-string (first s)))))
   (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
                         #"EOF while reading"
                         (p/parse-string "'" {:quote true})))


### PR DESCRIPTION
IMPORTANT: The test isn't right.

For some reason the `thrown-with-data?` check expects nil for the message field.