### PR TITLE
Add docs, tests for `:unquote`, `:unquote-splicing`

### DIFF
--- a/src/edamame/core.cljc
+++ b/src/edamame/core.cljc
@@ -8,7 +8,8 @@
 (defn parse-string
   "Parses first EDN value from string.
 
-  Supported parsing options:
+  Supported parsing options can be `true` for default behavior or a function
+  that is called on the form and returns a form in its place:
 
   `:deref`: parse forms starting with `@`. If `true`, the resulting
   expression will be parsed as `(deref expr)`.
@@ -23,13 +24,24 @@
   `:regex`: parse regex literals (`#\"foo\"`). If `true`, defaults to
   `re-pattern`.
 
-  `:syntax-quote`: parse syntax-quote (`(+ 1 2 3)`). Symbols get
-  qualified using `:resolve-symbol` which defaults to `identity`:
-  `(parse-string \"`x\" {:syntax-quote {:resolve-symbol #(symbol \"user\" (str %))}})
-  ;;=> (quote user/x)`.
-
   `:var`: parse var literals (`#'foo`). If `true`, the resulting
   expression will be parsed as `(var foo)`.
+
+  `:syntax-quote`: parse syntax-quote (`(+ 1 2 3)`). Symbols get
+  qualified using `:resolve-symbol` which defaults to `identity`:
+  ```clojure
+  (parse-string \"`x\" {:syntax-quote {:resolve-symbol #(symbol \"user\" (str %))}})
+  ;;=> (quote user/x)
+  ```
+  By default, also parses `unquote` and `unquote-splicing` literals,
+  resolving them accordingly.
+
+  `:unquote`: parse unquote (`~x`). Requires `:syntax-quote` to be set.
+  If `true` and not inside `syntax-quote`, defaults to `clojure.core/unquote`.
+
+  `:unquote-splicing`: parse unquote-splicing (`~@x`). Requires `:syntax-quote`
+  to be set. If `true` and not inside `syntax-quote`, defaults
+  to `clojure.core/unquote-splicing`.
 
   `:all`: when `true`, the above options will be set to `true` unless
   explicitly provided.

--- a/src/edamame/impl/parser.cljc
+++ b/src/edamame/impl/parser.cljc
@@ -634,7 +634,7 @@
                       (v next-val))))))
             (throw-reader
              ctx reader
-             (str "Syntax unquote not allowed. Use the `:syntax-unquote` option")))
+             (str "Syntax unquote not allowed. Use the `:syntax-quote` option")))
           \( (parse-list ctx reader)
           \[ (parse-to-delimiter ctx reader \])
           \{ (parse-map ctx reader)

--- a/test/edamame/core_test.cljc
+++ b/test/edamame/core_test.cljc
@@ -406,6 +406,32 @@
                                               (fn [sym]
                                                 (symbol "user" (str sym)))}}))))
 
+(deftest unquote-test
+  (is (= '(clojure.core/unquote x)
+           (p/parse-string "~x" {:syntax-quote true})))
+  (is (= '(clojure.core/unquote x)
+           (p/parse-string "~x" {:syntax-quote true
+                                 :unquote true})))
+  (is (= '(uq x)
+         (p/parse-string "~x" {:syntax-quote true
+                               :unquote #(list 'uq %)})))
+  (is (= '(do (uq x))
+         (p/parse-string "(do ~x)" {:syntax-quote true
+                                    :unquote #(list 'uq %)}))))
+
+(deftest unquote-splicing-test
+  (is (= '(clojure.core/unquote-splicing x)
+         (p/parse-string "~@x" {:syntax-quote true})))
+  (is (= '(clojure.core/unquote-splicing x)
+         (p/parse-string "~@x" {:syntax-quote true
+                                :unquote-splicing true})))
+  (is (= '(uqs x)
+         (p/parse-string "~@x" {:syntax-quote true
+                                :unquote-splicing #(list 'uqs %)})))
+  (is (= '(do (uqs x))
+         (p/parse-string "(do ~@x)" {:syntax-quote true
+                                     :unquote-splicing #(list 'uqs %)}))))
+
 (deftest edge-cases-test
   (is (= '(quote x) (p/parse-string "' x" {:quote true})))
   (is (thrown-with-msg? #?(:clj Exception :cljs js/Error)
@@ -421,7 +447,7 @@
   (is (:foo (meta (p/parse-string "^:foo []"))))
   (let [with-meta-val (p/parse-string "`^:foo []" {:syntax-quote true})]
     #?(:clj (is (:foo (meta (eval with-meta-val))))
-       :cljs (= 'clojure.core/with-meta (first with-meta-val)))))
+       :cljs (is (= 'clojure.core/with-meta (first with-meta-val))))))
 
 (deftest shebang-test
   (let [m (p/parse-string "#!/usr/bin/env bash\n{:a 1}")]


### PR DESCRIPTION
Follow-up to conversation with @borkdude [on slack](https://clojurians.slack.com/archives/C04QVMQ39LG/p1683995274112179?thread_ts=1683986986.536509&cid=C04QVMQ39LG).

* Add information about `:unquote` and `:unquote-splicing` options to `edamame.core/parse-string`.
* Note that each of the "supported parsing options" can take a 1-arg function instead of `true`.
* Fix small typo in `throw-reader` call for `:syntax-quote`.
* Add tests for both `:unquote` and `:unquote-splicing` outside of `syntax-quote` contexts.