### PR TITLE
Add support for #^ reader macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes)
 
 [Edamame](https://github.com/borkdude/edamame): configurable EDN and Clojure parser with location metadata and more
 
+## Unreleased
+
+- Fix [#125](https://github.com/borkdude/edamame/issues/125): Support `#^:foo` deprecated metadata reader macro.
+
 ## 1.4.30
 
 - [#120](https://github.com/borkdude/edamame/issues/120): fix `:auto-resolve-ns` failing case

--- a/src/edamame/impl/parser.cljc
+++ b/src/edamame/impl/parser.cljc
@@ -528,6 +528,12 @@
       \# (do
            (r/read-char reader)
            (read-symbolic-value reader nil nil))
+      \^ (do
+           (r/read-char reader) ;; ignore ^
+           (let [meta-val (parse-next ctx reader true)
+                 val-val (vary-meta (parse-next ctx reader)
+                                    merge meta-val)]
+             val-val))
       ;; catch-all
       (if (dispatch-macro? c)
         (do (r/unread reader \#)

--- a/test/edamame/core_test.cljc
+++ b/test/edamame/core_test.cljc
@@ -265,6 +265,8 @@
          (map meta (p/parse-string "[#_#_ ar gu ment]")))))
 
 (deftest meta-test
+  (is (:foo (meta (p/parse-string "^:foo [1 2 3]" {:all true}))))
+  (is (:foo (meta (p/parse-string "#^:foo [1 2 3]" {:all true}))))
   (is (= '{:row 1, :col 1, :end-row 1, :end-col 34, :arglists (quote ([& items]))}
          (meta (p/parse-string "^{:arglists '([& items])} [1 2 3]" {:all true})))))
 


### PR DESCRIPTION
I chose to duplicate the code, as that felt less invasive than pulling out the duplicates into a shared function. I can do that if you desire.

Closes #125